### PR TITLE
Small fix: add function "table.contains_substring"

### DIFF
--- a/valleys_c/deco.lua
+++ b/valleys_c/deco.lua
@@ -1,4 +1,19 @@
+function table.contains_substring(t, s)
+	if type(s) ~= "string" then
+		return nil
+	end
 
+	for key, value in pairs(t) do
+		if type(value) == 'string' and s:find(value) then
+			if key then
+				return key
+			else
+				return true
+			end
+		end
+	end
+	return false
+end
 
 -- Copy all the decorations except the ones I don't like.
 --  This is currently used to remove the default trees.


### PR DESCRIPTION
The code wasn't working because of a nil value error. The function `table.contains_substring` was missing.
```
ERROR[Main]: ModError: Failed to load and run script from /home/gael/.minetest/mods/lib_ecology/init.lua:
ERROR[Main]: /home/gael/.minetest/mods/lib_ecology/valleys_c/deco.lua:8: attempt to call field 'contains_substring' (a nil value)
ERROR[Main]: stack traceback:
ERROR[Main]: 	/home/gael/.minetest/mods/lib_ecology/valleys_c/deco.lua:8: in main chunk
ERROR[Main]: 	[C]: in function 'dofile'
ERROR[Main]: 	/home/gael/.minetest/mods/lib_ecology/init.lua:270: in main chunk
ERROR[Main]: Check debug.txt for details.
```
This is fixed by adding this function from duane-r's repository, in [deco.lua lines 76-91](https://github.com/duane-r/valleys_c/blob/82bc322/deco.lua#L76-L91).